### PR TITLE
Introducing image_generation to Jigsawstack-python:

### DIFF
--- a/jigsawstack/__init__.py
+++ b/jigsawstack/__init__.py
@@ -15,11 +15,13 @@ from .geo import Geo, AsyncGeo
 from .prompt_engine import PromptEngine, AsyncPromptEngine
 from .embedding import Embedding, AsyncEmbedding
 from .exceptions import JigsawStackError
+from .image_generation import ImageGeneration, AsyncImageGeneration
 
 
 class JigsawStack:
     audio: Audio
     vision: Vision
+    image_generation: ImageGeneration
     file: Store
     web: Web
     search: Search
@@ -116,6 +118,11 @@ class JigsawStack:
             api_url=api_url,
             disable_request_logging=disable_request_logging,
         ).execute
+        self.image_generation = ImageGeneration(
+            api_key=api_key,
+            api_url=api_url,
+            disable_request_logging=disable_request_logging,
+        ).image_generation
 
 
 class AsyncJigsawStack:
@@ -124,6 +131,7 @@ class AsyncJigsawStack:
     web: AsyncWeb
     audio: AsyncAudio
     vision: AsyncVision
+    image_generation: AsyncImageGeneration
     store: AsyncStore
     prompt_engine: AsyncPromptEngine
     api_key: str
@@ -226,6 +234,12 @@ class AsyncJigsawStack:
             api_url=api_url,
             disable_request_logging=disable_request_logging,
         ).execute
+
+        self.image_generation = AsyncImageGeneration(
+            api_key=api_key,
+            api_url=api_url,
+            disable_request_logging=disable_request_logging,
+        ).image_generation
 
 
 # Create a global instance of the Web class

--- a/jigsawstack/image_generation.py
+++ b/jigsawstack/image_generation.py
@@ -1,0 +1,103 @@
+from typing import Any, Dict, List, Union, cast
+from typing_extensions import NotRequired, TypedDict, Literal
+from .request import Request, RequestConfig
+from .async_request import AsyncRequest
+
+from typing import List, Union
+from ._config import ClientConfig
+
+class ImageGenerationparams(TypedDict):
+    prompt: str
+    """"
+    The text to generate the image from."
+    """
+    aspect_ratio: Literal["1:1", "16:9", "21:9", "3:2", "2:3", "4:5", "5:4", "3:4", "4:3", "9:16", "9:21"]
+    """
+    The aspect ratio of the image. The default is 1:1.
+    """
+    width: NotRequired[int]
+    """"
+    The width of the image. The default is 512."
+    """
+    height: NotRequired[int]
+    """
+    The height of the image. The default is 512."
+    """
+    steps: NotRequired[int]
+    """"
+    The number of steps to generate the image.""
+    """
+    advance_config: NotRequired[Dict[str, Union[int, str]]]
+    """
+    The advance configuration for the image generation. The default is None.
+    You can pass the following:
+    - `seed`: The seed for the image generation. The default is None.
+    - `guidance`: The guidance for the image generation. The default is None.
+    - `negative_prompt`: The negative prompt for the image generation. The default is None.
+    """
+
+class ImageGenerationResponse(TypedDict):
+    success: bool
+    """
+    Indicates whether the image generation was successful.
+    """
+    image: bytes
+    """
+    The generated image as a blob.
+    """
+
+class ImageGeneration(ClientConfig):
+    config: RequestConfig
+
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str,
+        disable_request_logging: Union[bool, None] = False,
+    ):
+        super().__init__(api_key, api_url, disable_request_logging=disable_request_logging)
+        self.config = RequestConfig(
+            api_url=api_url,
+            api_key=api_key,
+            disable_request_logging=disable_request_logging,
+        )
+
+    def image_generation(self, params: ImageGenerationparams) -> ImageGenerationResponse:
+        path = "/ai/image_generation"
+        resp = Request(
+            config=self.config,
+            path=path,
+            params=cast(Dict[Any, Any], params), # type: ignore
+            verb="post",
+        ).perform()
+        return resp
+    
+class AsyncImageGeneration(ClientConfig):
+    config: RequestConfig
+
+    def __init__(
+        self,
+        api_key: str,
+        api_url: str,
+        disable_request_logging: Union[bool, None] = False,
+    ):
+        super().__init__(api_key, api_url, disable_request_logging=disable_request_logging)
+        self.config = RequestConfig(
+            api_url=api_url,
+            api_key=api_key,
+            disable_request_logging=disable_request_logging,
+        )
+
+    async def image_generation(self, params: ImageGenerationparams) -> ImageGenerationResponse:
+        path = "/ai/image_generation"
+        resp = await AsyncRequest(
+            config=self.config,
+            path=path,
+            params=cast(Dict[Any, Any], params), # type: ignore
+            verb="post",
+        ).perform()
+        return resp
+    
+
+
+    

--- a/jigsawstack/request.py
+++ b/jigsawstack/request.py
@@ -56,7 +56,9 @@ class Request(Generic[T]):
 
         # this is a safety net, if we get here it means the JigsawStack API is having issues
         # and most likely the gateway is returning htmls
-        if "application/json" not in resp.headers["content-type"] and "audio/wav" not in resp.headers["content-type"]:
+        if "application/json" not in resp.headers["content-type"] \
+            and "audio/wav" not in resp.headers["content-type"] \
+            and "image/png" not in resp.headers["content-type"]:
             raise_for_code_and_type(
                 code=500,
                 message="Failed to parse JigsawStack API response. Please try again.",
@@ -72,9 +74,9 @@ class Request(Generic[T]):
                 err=error.get("error"),
             )
 
-        if "audio/wav" in resp.headers["content-type"]:
+        if "audio/wav" or "image/png" in resp.headers["content-type"]:
             return cast(T, resp) # we return the response object, instead of the json
-
+        
         return cast(T, resp.json())
 
     def perform_file(self) -> Union[T, None]:


### PR DESCRIPTION
1. image_generation.py:
	- Defined params and response types for ImageGeneration.
	- Defined a new class/module for ImageGeneration & AsyncImageGeneration.
2. request.py:
	- Since the response is bytes as type, and content-type is "image/png" within its headers, we introduce a new content-type before raising a parsing error, otherwise.
3. jigsawstack:
	- Added ImageGeneration and AsyncImageGeneration to jigsawstack.


Sample usecase:
```python
from jigsawstack import JigsawStack
jigsawstack = JigsawStack()

from pprint import pprint

import logging
logging.basicConfig(level=logging.DEBUG)
logging.getLogger("urllib3").setLevel(logging.DEBUG)

response = jigsawstack.image_generation(
    {"prompt": "A puppy playing in dog park."}
)

pprint(response)

import IPython.display as ipd
ipd.Image(response.content)
```

![output](https://github.com/user-attachments/assets/ae33f8fc-73b3-4e77-8ab1-aadda38056a4)
