### PR TITLE
V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,11 @@ To learn more about all available JigsawStack AI services, view the [Documentati
 | ----------------- | -------------------------------------------------- |
 | **👉 General**    | Translation, Summarization, Sentiment Analysis     |
 | **🌐 Web**        | AI Web Scraping, AI Web Search                     |
-| **🎵 Audio**      | Text to Speech, Speech to Text (Whisper large v3)  |
+| **🎵 Audio**      | Text to Speech, Speech to Text                     |
 | **👀 Vision**     | vOCR, Object Detection                             |
 | **🧠 LLMs**       | Prompt Engine                                      |
 | **🖼️ Generative** | AI Image (Flux, SD, SDXL-Fast & more), HTML to Any |
-| **🌍 Geo**        | Location search                                    |
 | **✅ Validation** | Email, NSFW images, profanity & more               |
-| **📁 Store**      | Simple File Storage                                |
 
 Learn more of about each category in the [API reference](https://docs.jigsawstack.com/api-reference)
 

--- a/jigsawstack/__init__.py
+++ b/jigsawstack/__init__.py
@@ -11,7 +11,6 @@ from .web import Web, AsyncWeb
 from .sentiment import Sentiment, AsyncSentiment
 from .validate import Validate, AsyncValidate
 from .summary import Summary, AsyncSummary
-from .geo import Geo, AsyncGeo
 from .prompt_engine import PromptEngine, AsyncPromptEngine
 from .embedding import Embedding, AsyncEmbedding
 from .exceptions import JigsawStackError
@@ -25,7 +24,6 @@ class JigsawStack:
     file: Store
     web: Web
     search: Search
-    geo: Geo
     prompt_engine: PromptEngine
     api_key: str
     api_url: str
@@ -103,11 +101,7 @@ class JigsawStack:
             api_url=api_url,
             disable_request_logging=disable_request_logging,
         ).translate
-        self.geo = Geo(
-            api_key=api_key,
-            api_url=api_url,
-            disable_request_logging=disable_request_logging,
-        )
+        
         self.prompt_engine = PromptEngine(
             api_key=api_key,
             api_url=api_url,
@@ -126,7 +120,6 @@ class JigsawStack:
 
 
 class AsyncJigsawStack:
-    geo: AsyncGeo
     validate: AsyncValidate
     web: AsyncWeb
     audio: AsyncAudio
@@ -161,12 +154,6 @@ class AsyncJigsawStack:
         self.api_url = api_url
 
         self.web = AsyncWeb(
-            api_key=api_key,
-            api_url=api_url,
-            disable_request_logging=disable_request_logging,
-        )
-
-        self.geo = AsyncGeo(
             api_key=api_key,
             api_url=api_url,
             disable_request_logging=disable_request_logging,

--- a/jigsawstack/async_request.py
+++ b/jigsawstack/async_request.py
@@ -39,72 +39,65 @@ class AsyncRequest(Generic[T]):
     async def perform(self) -> Union[T, None]:
         """
         Async method to make an HTTP request to the JigsawStack API.
-
-        Returns:
-            Union[T, None]: A generic type of the Request class or None
-
-        Raises:
-            aiohttp.ClientResponseError: If the request fails
         """
         async with self.__get_session() as session:
             resp = await self.make_request(session, url=f"{self.api_url}{self.path}")
 
-            # delete calls do not return a body
-            if await resp.text() == "" and resp.status == 200:
-                return None
+            # For binary responses
+            if resp.status == 200:
+                content_type = resp.headers.get("content-type", "")
+                if content_type not in ["application/json", "text/html"]:
+                    content = await resp.read()
+                    return cast(T, content)
 
-            # safety net for non-JSON responses
-            content_type = resp.headers.get("content-type", "")
-            if "application/json" not in content_type:
-                raise_for_code_and_type(
-                    code=500,
-                    message="Failed to parse JigsawStack API response. Please try again.",
-                )
-
-            # handle error responses
+            # For error responses
             if resp.status != 200:
-                error = await resp.json()
-                raise_for_code_and_type(
-                    code=resp.status,
-                    message=error.get("message"),
-                    err=error.get("error"),
-                )
+                try:
+                    error = await resp.json()
+                    raise_for_code_and_type(
+                        code=resp.status,
+                        message=error.get("message"),
+                        err=error.get("error"),
+                    )
+                except json.JSONDecodeError:
+                    raise_for_code_and_type(
+                        code=500,
+                        message="Failed to parse response. Invalid content type or encoding.",
+                    )
+
+            # For JSON responses
+            try:
+                return cast(T, await resp.json())
+            except json.JSONDecodeError:
+                content = await resp.read()
+                return cast(T, content)
+
+    async def perform_file(self) -> Union[T, None]:
+        async with self.__get_session() as session:
+            resp = await self.make_request(session, url=f"{self.api_url}{self.path}")
+
+            if resp.status != 200:
+                try:
+                    error = await resp.json()
+                    raise_for_code_and_type(
+                        code=resp.status,
+                        message=error.get("message"),
+                        err=error.get("error"),
+                    )
+                except json.JSONDecodeError:
+                    raise_for_code_and_type(
+                        code=500,
+                        message="Failed to parse response. Invalid content type or encoding.",
+                    )
+
+            # For binary responses
+            if resp.status == 200:
+                content_type = resp.headers.get("content-type", "")
+                if "application/json" not in content_type:
+                    content = await resp.read()
+                    return cast(T, content)
 
             return cast(T, await resp.json())
-
-    async def perform_file(self) -> Union[aiohttp.ClientResponse, None]:
-        """
-        Async method to make an HTTP request and return the raw response.
-
-        Returns:
-            Union[aiohttp.ClientResponse, None]: The raw response object
-        """
-        async with self.__get_session() as session:
-            resp = await self.make_request(session, url=f"{self.api_url}{self.path}")
-
-            # delete calls do not return a body
-            if await resp.text() == "" and resp.status == 200:
-                return None
-
-            # handle error responses
-            if (
-                "application/json" not in resp.headers.get("content-type", "")
-                and resp.status != 200
-            ):
-                raise_for_code_and_type(
-                    code=500,
-                    message="Failed to parse JigsawStack API response. Please try again.",
-                    error_type="InternalServerError",
-                )
-
-            if resp.status != 200:
-                error = await resp.json()
-                raise_for_code_and_type(
-                    code=resp.status,
-                    message=error.get("message"),
-                    err=error.get("error"),
-                )
-            return resp
 
     async def perform_with_content(self) -> T:
         """

--- a/jigsawstack/async_request.py
+++ b/jigsawstack/async_request.py
@@ -46,7 +46,7 @@ class AsyncRequest(Generic[T]):
             # For binary responses
             if resp.status == 200:
                 content_type = resp.headers.get("content-type", "")
-                if content_type not in ["application/json", "text/html"]:
+                if not resp.text or any(t in content_type for t in ["audio/", "image/", "application/octet-stream", "image/png"]):
                     content = await resp.read()
                     return cast(T, content)
 

--- a/jigsawstack/helpers.py
+++ b/jigsawstack/helpers.py
@@ -1,0 +1,29 @@
+# Helper method that:
+# Accepts a dictionary ro typed dictionary or None
+# Also accepts a path for url endpont,
+# Builds the url endpoint with non None values where the key is the parameter name & the value is the parameter value
+# Returns the url endpoint with the parameters
+from typing import Dict, Optional, Union
+from urllib.parse import urlencode
+
+def build_path(base_path: str, params: Optional[Dict[str, Union[str, int, bool]]] = None) -> str:
+    """
+    Build an API endpoint path with query parameters.
+
+    Args:
+        base_path (str): The base path endpoint (e.g. '/store/file')
+        params (Optional[Dict[str, Union[str, int, bool]]]): A dictionary of query parameters
+
+    Returns:
+        str: The constructed path with query parameters
+    """
+    if params is None:
+        return base_path
+    
+    #remove None values from the parameters
+    filtered_params = {k: v for k, v in params.items() if v is not None}
+
+    #encode the parameters
+    return f"{base_path}?{urlencode(filtered_params)}" if filtered_params else base_path
+
+

--- a/jigsawstack/helpers.py
+++ b/jigsawstack/helpers.py
@@ -1,8 +1,4 @@
-# Helper method that:
-# Accepts a dictionary ro typed dictionary or None
-# Also accepts a path for url endpont,
-# Builds the url endpoint with non None values where the key is the parameter name & the value is the parameter value
-# Returns the url endpoint with the parameters
+
 from typing import Dict, Optional, Union
 from urllib.parse import urlencode
 

--- a/jigsawstack/prompt_engine.py
+++ b/jigsawstack/prompt_engine.py
@@ -4,6 +4,7 @@ from .request import Request, RequestConfig
 from .async_request import AsyncRequest
 from typing import List, Union
 from ._config import ClientConfig
+from .helpers import build_path
 
 
 class PromptEngineResult(TypedDict):
@@ -137,10 +138,10 @@ class PromptEngine(ClientConfig):
         if params.get("page") is None:
             params["page"] = 0
 
-        limit = params.get("limit")
-        page = params.get("page")
-
-        path = f"/prompt_engine?limit={limit}&page={page}"
+        path = build_path(
+            base_path="/prompt_engine",
+            params=params,
+        )
         resp = Request(
             config=self.config, path=path, params={}, verb="get"
         ).perform_with_content()
@@ -253,10 +254,10 @@ class AsyncPromptEngine(ClientConfig):
         if params.get("page") is None:
             params["page"] = 0
 
-        limit = params.get("limit")
-        page = params.get("page")
-
-        path = f"/prompt_engine?limit={limit}&page={page}"
+        path = build_path(
+            base_path="/prompt_engine",
+            params=params,
+        )
         resp = await AsyncRequest(
             config=self.config, path=path, params={}, verb="get"
         ).perform_with_content()

--- a/jigsawstack/request.py
+++ b/jigsawstack/request.py
@@ -50,13 +50,13 @@ class Request(Generic[T]):
         """
         resp = self.make_request(url=f"{self.api_url}{self.path}")
 
-        # For binary responses or empty responses
+        #for binary responses
         if resp.status_code == 200:
             content_type = resp.headers.get("content-type", "")
-            if not resp.text or any(t in content_type for t in ["audio/", "image/", "application/octet-stream"]):
-                return cast(T, resp)
+            if not resp.text or any(t in content_type for t in ["audio/", "image/", "application/octet-stream", "image/png"]):
+                return cast(T, resp.content)
 
-        # Handle errors and JSON responses
+        #for json resposes.
         if resp.status_code != 200:
             try:
                 error = resp.json()
@@ -104,6 +104,12 @@ class Request(Generic[T]):
                 message=error.get("message"),
                 err=error.get("error"),
             )
+
+        #for binary responses
+        if resp.status_code == 200:
+            content_type = resp.headers.get("content-type", "")
+            if "application/json" not in content_type:
+                resp = cast(T, resp.content)
         return resp
 
     def perform_with_content(self) -> T:

--- a/jigsawstack/request.py
+++ b/jigsawstack/request.py
@@ -50,34 +50,32 @@ class Request(Generic[T]):
         """
         resp = self.make_request(url=f"{self.api_url}{self.path}")
 
-        # delete calls do not return a body
-        if resp.text == "" and resp.status_code == 200:
-            return None
+        # For binary responses or empty responses
+        if resp.status_code == 200:
+            content_type = resp.headers.get("content-type", "")
+            if not resp.text or any(t in content_type for t in ["audio/", "image/", "application/octet-stream"]):
+                return cast(T, resp)
 
-        # this is a safety net, if we get here it means the JigsawStack API is having issues
-        # and most likely the gateway is returning htmls
-        if "application/json" not in resp.headers["content-type"] \
-            and "audio/wav" not in resp.headers["content-type"] \
-            and "image/png" not in resp.headers["content-type"]:
-            raise_for_code_and_type(
-                code=500,
-                message="Failed to parse JigsawStack API response. Please try again.",
-            )
-
-        # handle error in case there is a statusCode attr present
-        # and status != 200 and response is a json.
+        # Handle errors and JSON responses
         if resp.status_code != 200:
-            error = resp.json()
-            raise_for_code_and_type(
-                code=resp.status_code,
-                message=error.get("message"),
-                err=error.get("error"),
-            )
+            try:
+                error = resp.json()
+                raise_for_code_and_type(
+                    code=resp.status_code,
+                    message=error.get("message"),
+                    err=error.get("error"),
+                )
+            except json.JSONDecodeError:
+                raise_for_code_and_type(
+                    code=500,
+                    message="Failed to parse response. Invalid content type or encoding.",
+                )
 
-        if "audio/wav" or "image/png" in resp.headers["content-type"]:
-            return cast(T, resp) # we return the response object, instead of the json
-        
-        return cast(T, resp.json())
+        # For JSON responses
+        try:
+            return cast(T, resp.json())
+        except json.JSONDecodeError:
+            return cast(T, resp)
 
     def perform_file(self) -> Union[T, None]:
 

--- a/jigsawstack/store.py
+++ b/jigsawstack/store.py
@@ -116,7 +116,7 @@ class AsyncStore(ClientConfig):
 
     async def delete(self, key: str) -> FileDeleteResponse:
         path = f"/store/file/read/{key}"
-        resp = AsyncRequest(
+        resp = await AsyncRequest(
             config=self.config,
             path=path,
             params=key,

--- a/jigsawstack/store.py
+++ b/jigsawstack/store.py
@@ -35,7 +35,6 @@ class Store(ClientConfig):
             options = {}
             
         path = build_path(base_path="/store/file", params=options)
-        print(path)
         content_type = options.get("content_type", "application/octet-stream")
         
         _headers = {"Content-Type": content_type}
@@ -93,14 +92,11 @@ class AsyncStore(ClientConfig):
             options = {}
             
         path = build_path(base_path="/store/file", params=options)
-        content_type = options.get("content_type")
-        _headers = {"Content-Type": "application/octet-stream"}
-        if content_type is not None:
-            _headers = {"Content-Type": content_type}
-
+        content_type = options.get("content_type", "application/octet-stream")
+        _headers = {"Content-Type": content_type}
         resp = await AsyncRequest(
             config=self.config,
-            params={},  # Empty params since we're using them in the URL
+            params=options,  # Empty params since we're using them in the URL
             path=path,
             data=file,
             headers=_headers,
@@ -123,7 +119,7 @@ class AsyncStore(ClientConfig):
         resp = AsyncRequest(
             config=self.config,
             path=path,
-            params=cast(Dict[Any, Any], params={}),
+            params=key,
             verb="delete",
         ).perform_with_content()
         return resp

--- a/jigsawstack/store.py
+++ b/jigsawstack/store.py
@@ -3,18 +3,14 @@ from typing_extensions import NotRequired, TypedDict
 from .request import Request, RequestConfig
 from .async_request import AsyncRequest, AsyncRequestConfig
 from ._config import ClientConfig
-
-
-
-
+from .helpers import build_path
+from .exceptions import JigsawStackError
 class FileDeleteResponse(TypedDict):
     success: bool
 
-
-
 class FileUploadParams(TypedDict):
-    overwrite: bool
-    filename: str
+    overwrite: NotRequired[bool]
+    filename: NotRequired[str]
     content_type: NotRequired[str]
 
 class Store(ClientConfig):
@@ -34,19 +30,19 @@ class Store(ClientConfig):
             disable_request_logging=disable_request_logging,
         )
 
-    def upload(self, file: bytes, options=FileUploadParams) -> Any:
-        overwrite = options.get("overwrite")
-        filename = options.get("filename")
-        params = {"key": filename, "overwrite": overwrite}
-        path = f"/store/file?overwrite={overwrite}&key={filename}"
-        content_type = options.get("content_type")
-        _headers = {"Content-Type": "application/octet-stream"}
-        if content_type is not None:
-            _headers = {"Content-Type": content_type}
+    def upload(self, file: bytes, options: Union[FileUploadParams, None] = None) -> Any:
+        if options is None:
+            options = {}
+            
+        path = build_path(base_path="/store/file", params=options)
+        print(path)
+        content_type = options.get("content_type", "application/octet-stream")
+        
+        _headers = {"Content-Type": content_type}
 
         resp = Request(
             config=self.config,
-            params=params,
+            params=options,  # Empty params since we're using them in the URL
             path=path,
             data=file,
             headers=_headers,
@@ -92,11 +88,11 @@ class AsyncStore(ClientConfig):
         )
         
 
-    async def upload(self, file: bytes, options=FileUploadParams) -> Any:
-        overwrite = options.get("overwrite")
-        filename = options.get("filename")
-        params = {"key": filename, "overwrite": overwrite}
-        path = f"/store/file?overwrite={overwrite}&key={filename}"
+    async def upload(self, file: bytes, options: Union[FileUploadParams, None] = None) -> Any:
+        if options is None:
+            options = {}
+            
+        path = build_path(base_path="/store/file", params=options)
         content_type = options.get("content_type")
         _headers = {"Content-Type": "application/octet-stream"}
         if content_type is not None:
@@ -104,7 +100,7 @@ class AsyncStore(ClientConfig):
 
         resp = await AsyncRequest(
             config=self.config,
-            params=params,
+            params={},  # Empty params since we're using them in the URL
             path=path,
             data=file,
             headers=_headers,

--- a/jigsawstack/translate.py
+++ b/jigsawstack/translate.py
@@ -6,6 +6,20 @@ from typing import List, Union
 from ._config import ClientConfig
 
 
+class TranslateImageParams(TypedDict):
+    target_language: str
+    """
+    Target langauge to translate to.
+    """
+    url: str
+    """
+    The URL of the image to translate.
+    """
+    file_store_key: NotRequired[str]
+    """
+    The file store key of the image to translate.
+    """
+
 class TranslateParams(TypedDict):
     target_language: str
     """
@@ -20,7 +34,6 @@ class TranslateParams(TypedDict):
     The text to translate.
     """
 
-
 class TranslateResponse(TypedDict):
     success: bool
     """
@@ -31,6 +44,15 @@ class TranslateResponse(TypedDict):
     The translated text.
     """
 
+class TranslateImageResponse(TypedDict):
+    success: bool
+    """
+    Indicates whether the translation was successful.
+    """
+    image: bytes
+    """
+    The image data that was translated.
+    """
 
 class TranslateListResponse(TypedDict):
     success: bool
@@ -61,15 +83,18 @@ class Translate(ClientConfig):
         )
 
     def translate(
-        self, params: TranslateParams
-    ) -> Union[TranslateResponse, TranslateListResponse]:
-        path = "/ai/translate"
+        self, params: Union[TranslateParams, TranslateImageParams]
+    ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageResponse]:
+        if "url" in params or "file_store_key" in params:
+            path = "/ai/translate/image"
+        else:
+            path = "/ai/translate"
         resp = Request(
             config=self.config,
             path=path,
             params=cast(Dict[Any, Any], params),
             verb="post",
-        ).perform_with_content()
+        ).perform()
         return resp
 
 
@@ -91,13 +116,16 @@ class AsyncTranslate(ClientConfig):
         )
 
     async def translate(
-        self, params: TranslateParams
-    ) -> Union[TranslateResponse, TranslateListResponse]:
-        path = "/ai/translate"
+        self, params: Union[TranslateParams, TranslateImageParams]
+    ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageParams]:
+        if "url" in params or "file_store_key" in params:
+            path = "/ai/translate/image"
+        else:
+            path = "/ai/translate"
         resp = await AsyncRequest(
             config=self.config,
             path=path,
             params=cast(Dict[Any, Any], params),
             verb="post",
-        ).perform_with_content()
+        ).perform()
         return resp

--- a/jigsawstack/translate.py
+++ b/jigsawstack/translate.py
@@ -154,5 +154,5 @@ class AsyncTranslate(ClientConfig):
         self, params: Union[TranslateParams, TranslateImageParams]
     ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageResponse]:
         if "url" in params or "file_store_key" in params:
-            return self.translate_image(params)
+            return await self.translate_image(params)
         return await self.translate_text(params)

--- a/jigsawstack/translate.py
+++ b/jigsawstack/translate.py
@@ -82,24 +82,37 @@ class Translate(ClientConfig):
             disable_request_logging=disable_request_logging,
         )
 
-    def translate(
-        self, params: Union[TranslateParams, TranslateImageParams]
-    ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageResponse]:
-        if "url" in params or "file_store_key" in params:
-            path = "/ai/translate/image"
-        else:
-            path = "/ai/translate"
+    def translate_text(
+        self, params: TranslateParams
+    ) -> Union[TranslateResponse, TranslateListResponse]:
         resp = Request(
             config=self.config,
-            path=path,
+            path="/ai/translate",
             params=cast(Dict[Any, Any], params),
             verb="post",
         ).perform()
         return resp
 
+    def translate_image(
+    self, params: TranslateImageParams
+) -> TranslateImageResponse:
+        resp = Request(
+            config=self.config,
+            path="/ai/translate/image",
+            params=cast(Dict[Any, Any], params),
+            verb="post",
+        ).perform()
+        return resp
+
+    def translate(
+    self, params: Union[TranslateParams, TranslateImageParams]
+) -> Union[TranslateResponse, TranslateListResponse, TranslateImageResponse]:
+        if "url" in params or "file_store_key" in params:
+            return self.translate_image(params)
+        return self.translate_text(params)
+
 
 class AsyncTranslate(ClientConfig):
-
     config: RequestConfig
 
     def __init__(
@@ -115,17 +128,31 @@ class AsyncTranslate(ClientConfig):
             disable_request_logging=disable_request_logging,
         )
 
-    async def translate(
-        self, params: Union[TranslateParams, TranslateImageParams]
-    ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageParams]:
-        if "url" in params or "file_store_key" in params:
-            path = "/ai/translate/image"
-        else:
-            path = "/ai/translate"
+    async def translate_text(
+        self, params: TranslateParams
+    ) -> Union[TranslateResponse, TranslateListResponse]:
         resp = await AsyncRequest(
             config=self.config,
-            path=path,
+            path="/ai/translate",
             params=cast(Dict[Any, Any], params),
             verb="post",
         ).perform()
         return resp
+
+    async def translate_image(
+        self, params: TranslateImageParams
+    ) -> TranslateImageResponse:
+        resp = await AsyncRequest(
+            config=self.config,
+            path="/ai/translate/image",
+            params=cast(Dict[Any, Any], params),
+            verb="post",
+        ).perform()
+        return resp
+
+    async def translate(
+        self, params: Union[TranslateParams, TranslateImageParams]
+    ) -> Union[TranslateResponse, TranslateListResponse, TranslateImageResponse]:
+        if "url" in params or "file_store_key" in params:
+            return self.translate_image(params)
+        return await self.translate_text(params)

--- a/jigsawstack/validate.py
+++ b/jigsawstack/validate.py
@@ -5,6 +5,7 @@ from .async_request import AsyncRequest, AsyncRequestConfig
 from ._config import ClientConfig
 from typing import Any, Dict, List, cast
 from typing_extensions import NotRequired, TypedDict
+from .helpers import build_path
 
 
 class Spam(TypedDict):
@@ -86,8 +87,11 @@ class Validate(ClientConfig):
         )
 
     def email(self, params: EmailValidationParams) -> EmailValidationResponse:
-        email = params.get("email")
-        path = f"/validate/email?email={email}"
+        path = build_path(
+            base_path="/validate/email",
+            params=params,
+        )
+
         resp = Request(
             config=self.config,
             path=path,
@@ -110,23 +114,25 @@ class Validate(ClientConfig):
         return resp
 
     def profanity(self, params: ProfanityParams) -> ProfanityResponse:
-        text = params.get("text")
-        censor_replacement = params.get("censor_replacement", "*")
-        path = f"/validate/profanity"
+        path = build_path(
+            base_path="/validate/profanity",
+            params=params,
+        )
         resp = Request(
             config=self.config,
             path=path,
             params=cast(
-                Dict[Any, Any], {"text": text, "censor_replacement": censor_replacement}
+                Dict[Any, Any], params
             ),
             verb="post",
         ).perform_with_content()
         return resp
 
     def spellcheck(self, params: SpellCheckParams) -> SpellCheckResponse:
-        text = params.get("text")
-        language_code = params.get("language_code", "en")
-        path = f"/validate/spell_check?text={text}&language_code={language_code}"
+        path = build_path(
+            base_path="/validate/spell_check",
+            params=params,
+        )
         resp = Request(
             config=self.config,
             path=path,
@@ -164,8 +170,7 @@ class AsyncValidate(ClientConfig):
         )
 
     async def email(self, params: EmailValidationParams) -> EmailValidationResponse:
-        email = params.get("email")
-        path = f"/validate/email?email={email}"
+        path = bui
         resp = await AsyncRequest(
             config=self.config,
             path=path,
@@ -188,23 +193,25 @@ class AsyncValidate(ClientConfig):
         return resp
 
     async def profanity(self, params: ProfanityParams) -> ProfanityResponse:
-        text = params.get("text")
-        censor_replacement = params.get("censor_replacement", "*")
-        path = f"/validate/profanity"
+        path = build_path(
+            base_path="/validate/profanity",
+            params=params,
+        )
         resp = await AsyncRequest(
             config=self.config,
             path=path,
             params=cast(
-                Dict[Any, Any], {"text": text, "censor_replacement": censor_replacement}
+                Dict[Any, Any], params
             ),
             verb="post",
         ).perform_with_content()
         return resp
 
     async def spellcheck(self, params: SpellCheckParams) -> SpellCheckResponse:
-        text = params.get("text")
-        language_code = params.get("language_code", "en")
-        path = f"/validate/spell_check?text={text}&language_code={language_code}"
+        path = build_path(
+            base_path="/validate/spell_check",
+            params=params,
+        )
         resp = await AsyncRequest(
             config=self.config,
             path=path,

--- a/jigsawstack/web.py
+++ b/jigsawstack/web.py
@@ -11,6 +11,7 @@ from .search import (
     SearchResponse,
     AsyncSearch,
 )
+from .helpers import build_path
 
 
 class DNSParams(TypedDict):
@@ -158,16 +159,6 @@ class Web(ClientConfig):
         ).perform_with_content()
         return resp
 
-    def scrape(self, params: ScrapeParams) -> ScrapeResponse:
-        path = "/web/scrape"
-        resp = Request(
-            config=self.config,
-            path=path,
-            params=cast(Dict[Any, Any], params),
-            verb="post",
-        ).perform_with_content()
-        return resp
-
     def html_to_any(self, params: HTMLToAnyParams) -> Any:
         path = "/web/html_to_any"
         resp = Request(
@@ -179,9 +170,10 @@ class Web(ClientConfig):
         return resp
 
     def dns(self, params: DNSParams) -> DNSResponse:
-        domain = params.get("domain", "")
-        type = params.get("type", "A")
-        path = f"/web/html_to_any?domain={domain}&type={type}"
+        path = build_path(
+            base_path="/web/html_to_any",
+            params=params,
+        )
         resp = Request(
             config=self.config,
             path=path,
@@ -257,9 +249,10 @@ class AsyncWeb(ClientConfig):
         return resp
 
     async def dns(self, params: DNSParams) -> DNSResponse:
-        domain = params.get("domain", "")
-        type = params.get("type", "A")
-        path = f"/web/html_to_any?domain={domain}&type={type}"
+        path = build_path(
+            base_path="/web/html_to_any",
+            params=params,
+        )
         resp = await AsyncRequest(
             config=self.config,
             path=path,

--- a/jigsawstack/web.py
+++ b/jigsawstack/web.py
@@ -110,7 +110,7 @@ class BYOProxy(TypedDict):
 
 class BaseAIScrapeParams(TypedDict):
     url: str
-    root_element_selectors: NotRequired[str]
+    root_element_selector: NotRequired[str]
     page_position: NotRequired[int]
     http_headers: NotRequired[Dict[str, Any]]
     reject_request_pattern: NotRequired[List[str]]

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.1.30",
+    version="0.1.31",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.1.32",
+    version="0.2.0",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.1.31",
+    version="0.1.32",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
# JigsawStack V3 Updates

1. `jigsawstack.web.scrape()` is now deprecated. [8a268f7](https://github.com/JigsawStack/jigsawstack-python/pull/42/commits/8a268f75b307d0346c8dbba1f25dfecabeafcd84)
2. `jigsawstack.web.ai_scrape()` can now accept both selectors and prompts.
3. `jigsawstack.geo` is now deprecated. [3121917](https://github.com/JigsawStack/jigsawstack-python/pull/42/commits/3121917d40603133eb04c39024276dbd59ac3444)
4. Other bug fixes, code enhancements and standardization. [af2022f](https://github.com/JigsawStack/jigsawstack-python/pull/42/commits/af2022f92d099645c5be17f571da3da1952f0133)