### PR TITLE
Update route for object_detection to match OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ dist/
 
 test.py
 test_web.py
+
+.eggs/
+.conda/

--- a/jigsawstack/version.py
+++ b/jigsawstack/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.2.8"
 
 
 def get_version() -> str:

--- a/jigsawstack/vision.py
+++ b/jigsawstack/vision.py
@@ -174,7 +174,7 @@ class Vision(ClientConfig):
         return resp
 
     def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse:
-        path = "/ai/object_detection"
+        path = "/object_detection"
         resp = Request(
             config=self.config,
             path=path,
@@ -211,7 +211,7 @@ class AsyncVision(ClientConfig):
         return resp
 
     async def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse:
-        path = "/ai/object_detection"
+        path = "/object_detection"
         resp = await AsyncRequest(
             config=self.config,
             path=path,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.2.7",
+    version="0.2.8",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request updates endpoint paths in the `object_detection` methods of the `jigsawstack/vision.py` file to remove the `/ai` prefix. The changes ensure consistency across synchronous and asynchronous implementations.

Endpoint updates:

* [`jigsawstack/vision.py`](diffhunk://#diff-b66385234e28379d7969dfa56394fc13faf77d5a8761bf3d08af85aa5a297ad6L177-R177): Updated the `path` variable in the `object_detection` method to remove the `/ai` prefix in both the synchronous (`def object_detection`) and asynchronous (`async def object_detection`) implementations. [[1]](diffhunk://#diff-b66385234e28379d7969dfa56394fc13faf77d5a8761bf3d08af85aa5a297ad6L177-R177) [[2]](diffhunk://#diff-b66385234e28379d7969dfa56394fc13faf77d5a8761bf3d08af85aa5a297ad6L214-R214)

Also updated .gitignore to avoid pushing conda-generated files.