### PR TITLE
fix: missing single binary upload.

### DIFF
--- a/jigsawstack/async_request.py
+++ b/jigsawstack/async_request.py
@@ -238,6 +238,7 @@ class AsyncRequest(Generic[T]):
         headers = self.__get_headers()
         params = self.params
         verb = self.verb
+        data = self.data
         files = self.files
 
         _params = None
@@ -254,6 +255,8 @@ class AsyncRequest(Generic[T]):
                 _form_data.add_field("body", json.dumps(params), content_type="application/json")
 
             headers.pop("Content-Type", None)
+        elif data:  # raw data request
+            _data = data
         else:  # pure JSON request
             _json = params
 

--- a/jigsawstack/request.py
+++ b/jigsawstack/request.py
@@ -247,6 +247,7 @@ class Request(Generic[T]):
         headers = self.__get_headers()
         params = self.params
         verb = self.verb
+        data = self.data
         files = self.files
 
         _requestParams = None
@@ -261,7 +262,8 @@ class Request(Generic[T]):
             if params and isinstance(params, dict):
                 _data = {"body": json.dumps(params)}
             headers.pop("Content-Type", None)  # let requests set it for multipart
-
+        elif data:  # raw data request
+            _data = data
         else:  # pure JSON request
             _json = params
         try:

--- a/jigsawstack/version.py
+++ b/jigsawstack/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.5"
+__version__ = "0.3.6"
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.3.5",
+    version="0.3.6",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Updated the request handling logic in both the asynchronous (`jigsawstack/async_request.py`) and synchronous (`jigsawstack/request.py`) request modules to better support raw data payloads. The main improvement is the addition of logic to correctly pass raw data when present, enhancing flexibility for different types of HTTP requests.

**Request payload handling improvements:**

* Both `make_request` methods now assign `self.data` to a local variable for easier access and processing. [[1]](diffhunk://#diff-59881b5865e4a54aa9529ef836b3518f0dea27b5568ae673e35d680862b80f26R241) [[2]](diffhunk://#diff-6d994944d6cf626e328c8d8d580402a04769bd8720e406515abe8b74df6de495R250)
* Added a conditional branch to check for raw data (`data`) and set the request payload accordingly, ensuring that raw data requests are handled properly in both async and sync flows. [[1]](diffhunk://#diff-59881b5865e4a54aa9529ef836b3518f0dea27b5568ae673e35d680862b80f26R258-R259) [[2]](diffhunk://#diff-6d994944d6cf626e328c8d8d580402a04769bd8720e406515abe8b74df6de495L264-R266)