### PR TITLE
typed now as object instead of object detection

### DIFF
--- a/jigsawstack/vision.py
+++ b/jigsawstack/vision.py
@@ -215,9 +215,7 @@ class Vision(ClientConfig):
         return resp
 
     @overload
-    def object_detection(
-        self, params: ObjectDetectionParams
-    ) -> ObjectDetectionResponse: ...
+    def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse: ...
     @overload
     def object_detection(
         self, blob: bytes, options: ObjectDetectionParams = None
@@ -297,9 +295,7 @@ class AsyncVision(ClientConfig):
         return resp
 
     @overload
-    async def object_detection(
-        self, params: ObjectDetectionParams
-    ) -> ObjectDetectionResponse: ...
+    async def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse: ...
     @overload
     async def object_detection(
         self, blob: bytes, options: ObjectDetectionParams = None

--- a/jigsawstack/vision.py
+++ b/jigsawstack/vision.py
@@ -102,9 +102,9 @@ class ObjectDetectionParams(TypedDict):
     List of prompts for object detection
     """
 
-    features: NotRequired[List[Literal["object_detection", "gui"]]]
+    features: NotRequired[List[Literal["object", "gui"]]]
     """
-    List of features to enable: object_detection, gui
+    List of features to enable: object, gui
     """
 
     annotated_image: NotRequired[bool]
@@ -215,7 +215,9 @@ class Vision(ClientConfig):
         return resp
 
     @overload
-    def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse: ...
+    def object_detection(
+        self, params: ObjectDetectionParams
+    ) -> ObjectDetectionResponse: ...
     @overload
     def object_detection(
         self, blob: bytes, options: ObjectDetectionParams = None
@@ -295,7 +297,9 @@ class AsyncVision(ClientConfig):
         return resp
 
     @overload
-    async def object_detection(self, params: ObjectDetectionParams) -> ObjectDetectionResponse: ...
+    async def object_detection(
+        self, params: ObjectDetectionParams
+    ) -> ObjectDetectionResponse: ...
     @overload
     async def object_detection(
         self, blob: bytes, options: ObjectDetectionParams = None

--- a/tests/test_object_detection.py
+++ b/tests/test_object_detection.py
@@ -18,7 +18,9 @@ logger = logging.getLogger(__name__)
 jigsaw = jigsawstack.JigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
 async_jigsaw = jigsawstack.AsyncJigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
 
-IMAGE_URL = "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg"
+IMAGE_URL = (
+    "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg"
+)
 
 TEST_CASES = [
     {
@@ -102,9 +104,7 @@ class TestObjectDetectionSync:
             if test_case.get("blob"):
                 # Download blob content
                 blob_content = requests.get(test_case["blob"]).content
-                result = jigsaw.vision.object_detection(
-                    blob_content, test_case.get("options", {})
-                )
+                result = jigsaw.vision.object_detection(blob_content, test_case.get("options", {}))
             else:
                 # Use params directly
                 result = jigsaw.vision.object_detection(test_case["params"])

--- a/tests/test_object_detection.py
+++ b/tests/test_object_detection.py
@@ -18,9 +18,7 @@ logger = logging.getLogger(__name__)
 jigsaw = jigsawstack.JigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
 async_jigsaw = jigsawstack.AsyncJigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
 
-IMAGE_URL = (
-    "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg"
-)
+IMAGE_URL = "https://rogilvkqloanxtvjfrkm.supabase.co/storage/v1/object/public/demo/Collabo%201080x842.jpg"
 
 TEST_CASES = [
     {
@@ -49,7 +47,7 @@ TEST_CASES = [
         "name": "with_blob_both_features",
         "blob": IMAGE_URL,
         "options": {
-            "features": ["object_detection", "gui"],
+            "features": ["object", "gui"],
             "annotated_image": True,
             "return_type": "url",
         },
@@ -63,7 +61,7 @@ TEST_CASES = [
         "name": "with_blob_object_detection_features",
         "blob": IMAGE_URL,
         "options": {
-            "features": ["object_detection"],
+            "features": ["object"],
             "annotated_image": True,
             "return_type": "base64",
         },
@@ -80,7 +78,7 @@ TEST_CASES = [
         "name": "with_all_options",
         "blob": IMAGE_URL,
         "options": {
-            "features": ["object_detection", "gui"],
+            "features": ["object", "gui"],
             "prompts": ["car", "road", "tree"],
             "annotated_image": True,
             "return_type": "base64",
@@ -104,7 +102,9 @@ class TestObjectDetectionSync:
             if test_case.get("blob"):
                 # Download blob content
                 blob_content = requests.get(test_case["blob"]).content
-                result = jigsaw.vision.object_detection(blob_content, test_case.get("options", {}))
+                result = jigsaw.vision.object_detection(
+                    blob_content, test_case.get("options", {})
+                )
             else:
                 # Use params directly
                 result = jigsaw.vision.object_detection(test_case["params"])


### PR DESCRIPTION
This pull request makes a small change to the `ObjectDetectionParams` type in `src/vision/interfaces.ts`, updating the possible values for the `features` property to use `"object"` instead of `"object_detection"`.

**Please merge only after main has the object as feature supported**