### PR TITLE
fix: missed base_url for ai_scrape url.

### DIFF
--- a/jigsawstack/version.py
+++ b/jigsawstack/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.3.8"
+__version__ = "0.3.9"
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.3.8",
+    version="0.3.9",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",
@@ -16,7 +16,7 @@ setup(
     packages=find_packages(include=["jigsawstack"]),
     install_requires=install_requires,
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     keywords=["AI", "AI Tooling"],
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "pytest-asyncio"],
@@ -27,10 +27,9 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tests/test_ai_scrape.py
+++ b/tests/test_ai_scrape.py
@@ -12,8 +12,20 @@ load_dotenv()
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-jigsaw = jigsawstack.JigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
-async_jigsaw = jigsawstack.AsyncJigsawStack(api_key=os.getenv("JIGSAWSTACK_API_KEY"))
+jigsaw = jigsawstack.JigsawStack(
+    base_url=os.getenv("JIGSAWSTACK_BASE_URL") + "/api"
+    if os.getenv("JIGSAWSTACK_BASE_URL")
+    else "https://api.jigsawstack.com",
+    api_key=os.getenv("JIGSAWSTACK_API_KEY"),
+    headers={"x-jigsaw-skip-cache": "true"},
+)
+async_jigsaw = jigsawstack.AsyncJigsawStack(
+    base_url=os.getenv("JIGSAWSTACK_BASE_URL") + "/api"
+    if os.getenv("JIGSAWSTACK_BASE_URL")
+    else "https://api.jigsawstack.com",
+    api_key=os.getenv("JIGSAWSTACK_API_KEY"),
+    headers={"x-jigsaw-skip-cache": "true"},
+)
 
 URL = "https://jigsawstack.com"
 
@@ -70,7 +82,9 @@ AI_SCRAPE_TEST_CASES = [
         "params": {
             "url": URL,
             "element_prompts": ["user data"],
-            "cookies": [{"name": "session", "value": "test123", "domain": "example.com"}],
+            "cookies": [
+                {"name": "session", "value": "test123", "domain": "example.com"}
+            ],
         },
     },
     {


### PR DESCRIPTION
This pull request updates the package version and modernizes Python compatibility requirements, while also improving test configuration for API usage. The most important changes are grouped below by theme.

**Version and Compatibility Updates:**

* Bumped the package version from `0.3.8` to `0.3.9` in both `jigsawstack/version.py` and `setup.py`. [[1]](diffhunk://#diff-b718be9ac7bcc1edb0113a85bcde6c8d788ad986868d410ec9320e8b53323d0aL1-R1) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L9-R9)
* Updated the minimum required Python version from 3.7 to 3.9 in `setup.py`, and removed support for Python 3.7 and 3.8 in the classifiers, adding support for Python 3.12. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L19-R19) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L30-R33)

**Test Configuration Improvements:**

* Modified the instantiation of `JigsawStack` and `AsyncJigsawStack` in `tests/test_ai_scrape.py` to use a configurable `base_url` and custom headers, improving flexibility and cache control in tests.
* Minor formatting update for cookie parameters in test configuration for better readability.