### PR TITLE
Fix/stt output

### DIFF
--- a/jigsawstack/audio.py
+++ b/jigsawstack/audio.py
@@ -77,14 +77,9 @@ class SpeechToTextResponse(BaseResponse):
     the speakers of the transcription, available if by_speaker is set to true
     """
 
-    language_detected: Optional[str]
+    language_detected: Optional[Dict[str, Any]]
     """
     the language detected in the transcription, available if language is set to auto
-    """
-
-    confidence: Optional[float]
-    """
-    the confidence of the transcription language detection, available if language is set to auto
     """
 
 

--- a/jigsawstack/version.py
+++ b/jigsawstack/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.4.0",
+    version="0.4.1",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This pull request updates the package version and modifies the structure of the language detection output in the speech-to-text response. The most important changes are listed below.

Version update:

* Updated the package version to `0.4.1` in both `setup.py` and `jigsawstack/version.py` for release tracking and distribution. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L9-R9) [[2]](diffhunk://#diff-b718be9ac7bcc1edb0113a85bcde6c8d788ad986868d410ec9320e8b53323d0aL1-R1)

Speech-to-text API changes:

* Changed the `language_detected` field in the `SpeechToTextResponse` class from an optional string to an optional dictionary, allowing for richer language detection metadata in the transcription response.
* Removed the `confidence` field from `SpeechToTextResponse`, simplifying the response and removing language detection confidence reporting.

NOTE: this is a breaking change for STT, for users using jigsawstack-python under and equal 0.4.0, when pointed, idea is to suggest the user to upgrade to 0.4.1 latest