### PR TITLE
Fix/stt response

### DIFF
--- a/jigsawstack/audio.py
+++ b/jigsawstack/audio.py
@@ -50,15 +50,10 @@ class SpeechToTextParams(TypedDict):
     """
 
 
-class ChunkParams(TypedDict):
+class ChunkResponse(TypedDict):
     text: str
     timestamp: tuple[int, int]
-
-
-class BySpeakerParams(ChunkParams):
-    speaker: str
-    timestamp: tuple[int, int]
-    text: str
+    speaker: Optional[str]
 
 
 class SpeechToTextResponse(BaseResponse):
@@ -67,14 +62,9 @@ class SpeechToTextResponse(BaseResponse):
     the text of the transcription
     """
 
-    chunks: List[ChunkParams]
+    chunks: List[ChunkResponse]
     """
     the chunks of the transcription
-    """
-
-    speakers: Optional[List[BySpeakerParams]]
-    """
-    the speakers of the transcription, available if by_speaker is set to true
     """
 
     language_detected: Optional[Dict[str, Any]]

--- a/jigsawstack/version.py
+++ b/jigsawstack/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 
 def get_version() -> str:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = open("requirements.txt").readlines()
 
 setup(
     name="jigsawstack",
-    version="0.4.2",
+    version="0.4.3",
     description="JigsawStack - The AI SDK for Python",
     long_description=open("README.md", encoding="utf8").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION

* Replaced `ChunkParams` and `BySpeakerParams` with a unified `ChunkResponse` type, which now includes an optional `speaker` field and a single `timestamp` tuple, simplifying chunk representation and removing redundant fields.
* Updated the `SpeechToTextResponse` class to use `List[ChunkResponse]` for the `chunks` field and removed the separate `speakers` field, consolidating speaker information into the chunk structure.