### PR TITLE
fix: __get_headers mutates caller's config dict on multipart requests

### DIFF
--- a/jigsawstack/async_request.py
+++ b/jigsawstack/async_request.py
@@ -35,9 +35,13 @@ class AsyncRequest(Generic[T]):
         self.base_url = config.get("base_url")
         self.api_key = config.get("api_key")
         self.data = data
-        self.headers = config.get("headers", None) or {"Content-Type": "application/json"}
+        # Defensive copy: we must not mutate the caller's config dict. Without
+        # this, __get_headers() could permanently strip keys (e.g. Content-Type)
+        # from the shared config that all service-class methods reuse.
+        raw_headers = config.get("headers", None) or {"Content-Type": "application/json"}
+        self.headers: Dict[str, str] = dict(raw_headers)
         self.stream = stream
-        self.files = files  # Store files for multipart requests
+        self.files = files
 
     def __convert_params(
         self, params: Union[Dict[Any, Any], List[Dict[Any, Any]]]
@@ -175,19 +179,22 @@ class AsyncRequest(Generic[T]):
             "x-api-key": f"{self.api_key}",
         }
 
-        # only add Content-Type if not using multipart (files)
+        # Only add Content-Type if not using multipart (files)
         if not self.files and not self.data:
             h["Content-Type"] = "application/json"
 
-        _headers = h.copy()
+        # Work on a local copy so we never mutate self.headers (which itself is
+        # already a copy of the original config dict — see __init__).
+        caller_headers = dict(self.headers)
 
-        # don't override Content-Type if using multipart
-        if self.files and "Content-Type" in self.headers:
-            self.headers.pop("Content-Type")
+        # Strip Content-Type for multipart requests so that aiohttp can set
+        # the correct multipart/form-data boundary itself.
+        if self.files:
+            caller_headers.pop("Content-Type", None)
 
-        _headers.update(self.headers)
+        h.update(caller_headers)
 
-        return _headers
+        return h
 
     async def perform_streaming(self) -> AsyncGenerator[Union[T, str], None]:
         """
@@ -253,8 +260,6 @@ class AsyncRequest(Generic[T]):
             _form_data.add_field("file", BytesIO(files["file"]), filename="upload")
             if params and isinstance(params, dict):
                 _form_data.add_field("body", json.dumps(params), content_type="application/json")
-
-            headers.pop("Content-Type", None)
         elif data:  # raw data request
             _data = data
         else:  # pure JSON request

--- a/jigsawstack/request.py
+++ b/jigsawstack/request.py
@@ -35,7 +35,11 @@ class Request(Generic[T]):
         self.base_url = config.get("base_url")
         self.api_key = config.get("api_key")
         self.data = data
-        self.headers = config.get("headers", None) or {"Content-Type": "application/json"}
+        # Defensive copy: we must not mutate the caller's config dict. Without
+        # this, __get_headers() could permanently strip keys (e.g. Content-Type)
+        # from the shared config that all service-class methods reuse.
+        raw_headers = config.get("headers", None) or {"Content-Type": "application/json"}
+        self.headers: Dict[str, str] = dict(raw_headers)
         self.stream = stream
         self.files = files
 
@@ -160,15 +164,18 @@ class Request(Generic[T]):
         if not self.files and not self.data:
             h["Content-Type"] = "application/json"
 
-        _headers = h.copy()
+        # Work on a local copy so we never mutate self.headers (which itself is
+        # already a copy of the original config dict — see __init__).
+        caller_headers = dict(self.headers)
 
-        # Don't override Content-Type if using multipart
-        if self.files and "Content-Type" in self.headers:
-            self.headers.pop("Content-Type")
+        # Strip Content-Type for multipart requests so that the requests
+        # library can set the correct multipart/form-data boundary itself.
+        if self.files:
+            caller_headers.pop("Content-Type", None)
 
-        _headers.update(self.headers)
+        h.update(caller_headers)
 
-        return _headers
+        return h
 
     def perform_streaming(self) -> Generator[Union[T, str], None, None]:
         """Is the main function that makes the HTTP request
@@ -261,7 +268,6 @@ class Request(Generic[T]):
             _files = files
             if params and isinstance(params, dict):
                 _data = {"body": json.dumps(params)}
-            headers.pop("Content-Type", None)  # let requests set it for multipart
         elif data:  # raw data request
             _data = data
         else:  # pure JSON request

--- a/tests/test_headers_mutation.py
+++ b/tests/test_headers_mutation.py
@@ -1,0 +1,153 @@
+"""
+tests/test_headers_mutation.py
+
+Regression tests for the __get_headers mutation bug.
+
+Both Request and AsyncRequest were holding a direct reference to the headers
+dict inside the caller's config TypedDict and calling .pop("Content-Type") on
+it during multipart file-upload requests.  That permanently modified the shared
+config, so every subsequent request reusing the same config would go out without
+Content-Type.
+
+These tests are self-contained and require no API key or network access.
+"""
+
+from typing import Optional
+
+from jigsawstack.async_request import AsyncRequest, AsyncRequestConfig
+from jigsawstack.request import Request, RequestConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _sync_config(extra_headers: Optional[dict] = None) -> RequestConfig:
+    headers = {"Content-Type": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return RequestConfig(base_url="http://test", api_key="key", headers=headers)
+
+
+def _async_config(extra_headers: Optional[dict] = None) -> AsyncRequestConfig:
+    headers = {"Content-Type": "application/json"}
+    if extra_headers:
+        headers.update(extra_headers)
+    return AsyncRequestConfig(base_url="http://test", api_key="key", headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Sync Request
+# ---------------------------------------------------------------------------
+
+class TestSyncRequestHeadersMutation:
+    def test_multipart_does_not_mutate_config_headers(self):
+        """A multipart request must not remove Content-Type from the config dict."""
+        config = _sync_config()
+        r = Request(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        r._Request__get_headers()
+        assert "Content-Type" in config["headers"], (
+            "__get_headers() stripped Content-Type from the caller's config dict"
+        )
+
+    def test_repeated_multipart_calls_do_not_degrade(self):
+        """Calling __get_headers() multiple times must always produce the same result."""
+        config = _sync_config()
+        r = Request(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        first = r._Request__get_headers()
+        second = r._Request__get_headers()
+        assert first == second, "__get_headers() returned different results on second call"
+
+    def test_multipart_output_omits_content_type(self):
+        """Outgoing headers for a multipart request must not contain Content-Type
+        so that the requests library can insert the correct multipart boundary."""
+        config = _sync_config()
+        r = Request(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        out = r._Request__get_headers()
+        assert "Content-Type" not in out, (
+            "Content-Type should be absent from multipart outgoing headers"
+        )
+
+    def test_json_request_includes_content_type(self):
+        """Plain JSON requests must still set Content-Type: application/json."""
+        config = _sync_config()
+        r = Request(config=config, path="/test", params={"k": "v"}, verb="post")
+        out = r._Request__get_headers()
+        assert out.get("Content-Type") == "application/json"
+
+    def test_custom_headers_propagated(self):
+        """Any extra caller-supplied headers must survive into the outgoing dict."""
+        config = _sync_config(extra_headers={"x-custom": "value"})
+        r = Request(config=config, path="/test", params={}, verb="post")
+        out = r._Request__get_headers()
+        assert out.get("x-custom") == "value"
+
+    def test_second_request_on_same_config_unaffected(self):
+        """A second Request built from the same config after a multipart call
+        must still produce correct headers — the config was not poisoned."""
+        config = _sync_config()
+        # First request: multipart — used to trigger the bug
+        r1 = Request(config=config, path="/test", params={}, verb="post", files={"file": b"x"})
+        r1._Request__get_headers()
+        # Second request: plain JSON — previously would be missing Content-Type
+        r2 = Request(config=config, path="/test", params={"k": "v"}, verb="post")
+        out = r2._Request__get_headers()
+        assert out.get("Content-Type") == "application/json", (
+            "Config was mutated by the first multipart request; second request lost Content-Type"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Async Request
+# ---------------------------------------------------------------------------
+
+class TestAsyncRequestHeadersMutation:
+    def test_multipart_does_not_mutate_config_headers(self):
+        """A multipart request must not remove Content-Type from the config dict."""
+        config = _async_config()
+        r = AsyncRequest(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        r._AsyncRequest__get_headers()
+        assert "Content-Type" in config["headers"], (
+            "__get_headers() stripped Content-Type from the caller's async config dict"
+        )
+
+    def test_repeated_multipart_calls_do_not_degrade(self):
+        """Calling __get_headers() multiple times must always produce the same result."""
+        config = _async_config()
+        r = AsyncRequest(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        first = r._AsyncRequest__get_headers()
+        second = r._AsyncRequest__get_headers()
+        assert first == second, "__get_headers() returned different results on second call"
+
+    def test_multipart_output_omits_content_type(self):
+        """Outgoing headers for a multipart request must not contain Content-Type."""
+        config = _async_config()
+        r = AsyncRequest(config=config, path="/test", params={}, verb="post", files={"file": b"data"})
+        out = r._AsyncRequest__get_headers()
+        assert "Content-Type" not in out
+
+    def test_json_request_includes_content_type(self):
+        """Plain JSON requests must still set Content-Type: application/json."""
+        config = _async_config()
+        r = AsyncRequest(config=config, path="/test", params={"k": "v"}, verb="post")
+        out = r._AsyncRequest__get_headers()
+        assert out.get("Content-Type") == "application/json"
+
+    def test_custom_headers_propagated(self):
+        """Any extra caller-supplied headers must survive into the outgoing dict."""
+        config = _async_config(extra_headers={"x-custom": "value"})
+        r = AsyncRequest(config=config, path="/test", params={}, verb="post")
+        out = r._AsyncRequest__get_headers()
+        assert out.get("x-custom") == "value"
+
+    def test_second_request_on_same_config_unaffected(self):
+        """A second AsyncRequest built from the same config after a multipart call
+        must still produce correct headers."""
+        config = _async_config()
+        r1 = AsyncRequest(config=config, path="/test", params={}, verb="post", files={"file": b"x"})
+        r1._AsyncRequest__get_headers()
+        r2 = AsyncRequest(config=config, path="/test", params={"k": "v"}, verb="post")
+        out = r2._AsyncRequest__get_headers()
+        assert out.get("Content-Type") == "application/json", (
+            "Config was mutated by the first multipart request; second request lost Content-Type"
+        )


### PR DESCRIPTION
## Problem

So every service class (`Audio`, `Translate`, `Vision`, etc.) creates a single `RequestConfig` / `AsyncRequestConfig` in its `__init__` and reuses it for every method call on that instance.

The bug was in how `Request.__init__` (and the async version) was setting headers:

```python
self.headers = config.get("headers", None) or {"Content-Type": "application/json"}
```

This isn't copying anything — it's just storing a reference to the same dict object that the service class holds onto. So when `__get_headers()` does:

```python
self.headers.pop("Content-Type")
```

...during a multipart upload, it's actually **wiping `Content-Type` out of the shared config for good**. Every call after that — JSON POSTs, GETs, whatever — goes out without `Content-Type: application/json` and you start getting silent 400/422s from the server.

The really annoying part is it only breaks on the **second call**, so it's easy to miss in basic tests and a pain to track down.

Same issue in both `request.py` and `async_request.py`.

## Fix

I went with a two-level defence in both files so there's no way either the config or `self.headers` gets touched:

1. **`__init__` — own the dict**
   ```python
   raw_headers = config.get("headers", None) or {"Content-Type": "application/json"}
   self.headers: Dict[str, str] = dict(raw_headers)
   ```
   Now `self.headers` is its own copy — whatever happens to it later, the caller's config is safe.

2. **`__get_headers()` — throwaway per-call copy**
   ```python
   caller_headers = dict(self.headers)
   if self.files:
       caller_headers.pop("Content-Type", None)
   h.update(caller_headers)
   ```
   `.pop()` only touches a local copy made fresh each call, so `self.headers` stays intact.

Also cleaned up the leftover `headers.pop("Content-Type", None)` in `make_request()` in both files — `__get_headers()` already handles that, so it was just dead code sitting there.

## Tests

Added `test_headers_mutation.py` — 12 tests, no API key or network needed:

| Test | Covers |
|------|--------|
| `test_multipart_does_not_mutate_config_headers` | Config dict is untouched after a multipart call |
| `test_repeated_multipart_calls_do_not_degrade` | Calling `__get_headers()` twice returns identical results |
| `test_multipart_output_omits_content_type` | Outgoing multipart headers correctly omit `Content-Type` so the HTTP library can set the boundary |
| `test_json_request_includes_content_type` | Plain JSON requests still carry `Content-Type: application/json` |
| `test_custom_headers_propagated` | Caller-supplied extra headers reach the outgoing dict |
| `test_second_request_on_same_config_unaffected` | A second `Request` built from the same config after a multipart call has correct headers — the original regression scenario |

All 6 run for both `Request` (sync) and `AsyncRequest` (async) — **12/12 pass**.

## Files changed
- `request.py`
- `async_request.py`
- `test_headers_mutation.py` *(new)*

---

### Contact
Thanks for reviewing — happy to fix something / reiterate if needed :D
[siddartha_ay@protonmail.com](mailto:siddartha_ay@protonmail.com) | (everything about me at [siddartha-ay.xyz](https://siddartha-ay.xyz/) )